### PR TITLE
Add market selection utilities and example script

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,44 @@
+# GeoLift Python
+
+This directory hosts a lightweight Python implementation of the GeoLift
+methodology.  The code focuses on building synthetic control groups and
+estimating uncertainty using [PyMC](https://www.pymc.io/).
+
+The key pieces are:
+
+* `SyntheticControlModel` &ndash; fits a Bayesian model to pre-treatment data
+  and produces a posterior distribution of counterfactual outcomes.
+* `prepare_wide_panel` and `select_test_market` &ndash; utilities for working
+  with a long form dataset containing many markets.  They pivot the data to
+  wide format and automatically choose a test market by finding the market with
+  the lowest correlation to the rest during the pre period.
+
+### Input Data
+
+Input should be provided in a **long** format `DataFrame` with columns
+`time`, `market`, and `outcome`.  Each row represents the observed outcome for
+one market at a point in time.  The helper `prepare_wide_panel` converts this
+into the **wide** format expected by `SyntheticControlModel`.
+
+### Running the example
+
+An example script `examples.py` demonstrates how to:
+
+1. Generate a synthetic panel of multiple markets.
+2. Automatically select a test market.
+3. Fit the model using PyMC.
+4. Visualize observed vs. counterfactual outcomes with `matplotlib`.
+
+Run it with:
+
+```bash
+python examples.py
+```
+
+### Interpreting results
+
+`examples.py` will display a plot showing the observed trajectory of the test
+market after the intervention compared to the mean predicted counterfactual.
+The gap between these lines represents the estimated lift, while the variation
+in predictions (accessible through the posterior samples) conveys the
+uncertainty around that lift estimate.

--- a/python/examples.py
+++ b/python/examples.py
@@ -1,0 +1,48 @@
+"""Demonstration of the GeoLift Python implementation."""
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from geolift import SyntheticControlModel, prepare_wide_panel, select_test_market
+
+
+# Generate a synthetic panel of markets
+np.random.seed(1)
+T = 50
+markets = ["A", "B", "C", "D"]
+records = []
+for m in markets:
+    trend = np.linspace(0, 5, T)
+    noise = np.random.normal(scale=0.5, size=T)
+    outcome = trend + noise
+    if m == "A":
+        outcome += np.where(np.arange(T) > 30, 3.0, 0)  # effect after time 30
+    for t, y in enumerate(outcome):
+        records.append({"time": t, "market": m, "outcome": y})
+
+df_long = pd.DataFrame(records)
+
+# Prepare wide panel and automatically choose a test market
+panel = prepare_wide_panel(df_long, "market", "outcome", "time")
+test_market = select_test_market(panel, pre_period_end=30)
+
+pre = panel[panel.time <= 30].rename(columns={test_market: "treated"})
+post_controls = panel[panel.time > 30].drop(columns=[test_market])
+
+# Fit synthetic control model and predict counterfactual
+scm = SyntheticControlModel(pre)
+scm.fit(draws=1000, tune=500, seed=42)
+
+counterfactual = scm.predict(post_controls)
+actual = panel.loc[panel.time > 30, test_market].reset_index(drop=True)
+
+# Plot observed vs. counterfactual
+plt.plot(post_controls.time.values, actual, label="Observed")
+plt.plot(post_controls.time.values, counterfactual, label="Counterfactual")
+plt.xlabel("time")
+plt.ylabel("outcome")
+plt.title(f"Test market: {test_market}")
+plt.legend()
+plt.tight_layout()
+plt.show()

--- a/python/geolift/__init__.py
+++ b/python/geolift/__init__.py
@@ -1,0 +1,10 @@
+"""GeoLift Python package."""
+
+from .synthetic_control import SyntheticControlModel
+from .market_selection import prepare_wide_panel, select_test_market
+
+__all__ = [
+    "SyntheticControlModel",
+    "prepare_wide_panel",
+    "select_test_market",
+]

--- a/python/geolift/market_selection.py
+++ b/python/geolift/market_selection.py
@@ -1,0 +1,41 @@
+"""Helpers for selecting test markets from a panel dataset."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+import numpy as np
+
+
+def prepare_wide_panel(
+    df: pd.DataFrame,
+    market_col: str,
+    outcome_col: str,
+    time_col: str,
+) -> pd.DataFrame:
+    """Pivot a long-form DataFrame into wide format by market."""
+    wide = df.pivot_table(index=time_col, columns=market_col, values=outcome_col)
+    wide = wide.reset_index().sort_values(time_col).reset_index(drop=True)
+    wide.columns.name = None
+    return wide
+
+
+def select_test_market(df_wide: pd.DataFrame, pre_period_end: int | float) -> str:
+    """Select a test market with minimal correlation to the others."""
+    market_cols = [c for c in df_wide.columns if c != "time"]
+    pre = df_wide[df_wide["time"] <= pre_period_end]
+
+    best_market = None
+    lowest_corr = None
+    for m in market_cols:
+        others = [c for c in market_cols if c != m]
+        if not others:
+            continue
+        corr = pre[m].corr(pre[others].mean(axis=1))
+        if lowest_corr is None or corr < lowest_corr:
+            lowest_corr = corr
+            best_market = m
+    if best_market is None:
+        raise ValueError("Unable to select test market")
+    return best_market

--- a/python/geolift/synthetic_control.py
+++ b/python/geolift/synthetic_control.py
@@ -1,0 +1,52 @@
+"""Synthetic control utilities implemented using PyMC.
+
+This module provides a simple interface for building a synthetic
+control model using Bayesian inference. The implementation mirrors the
+R library but leverages PyMC to obtain a posterior distribution over
+the synthetic control weights and resulting predictions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+
+
+@dataclass
+class SyntheticControlModel:
+    """Bayesian synthetic control model."""
+
+    pre_treatment: pd.DataFrame
+    trace: Optional[pm.backends.base.MultiTrace] = None
+
+    def fit(self, draws: int = 2000, tune: int = 1000, seed: Optional[int] = None) -> None:
+        """Fit the synthetic control model using MCMC."""
+        df = self.pre_treatment.sort_values("time").reset_index(drop=True)
+        controls = df.drop(columns=["time", "treated"]).values
+        treated = df["treated"].values
+
+        n_controls = controls.shape[1]
+
+        with pm.Model() as model:
+            w = pm.Dirichlet("w", a=np.ones(n_controls))
+            mu = pm.Deterministic("mu", pm.math.dot(controls, w))
+            sigma = pm.Exponential("sigma", 1.0)
+            pm.Normal("obs", mu=mu, sigma=sigma, observed=treated)
+
+            self.trace = pm.sample(draws=draws, tune=tune, random_seed=seed, progressbar=False)
+
+    def predict(self, post_controls: pd.DataFrame) -> pd.Series:
+        """Predict counterfactual outcomes for the treated unit."""
+        if self.trace is None:
+            raise RuntimeError("Model must be fit before prediction")
+
+        controls = post_controls.drop(columns=["time"], errors="ignore").values
+        w_samples = self.trace.posterior["w"].stack(draws=("chain", "draw")).values
+
+        preds = controls @ w_samples
+        pred_mean = preds.mean(axis=1)
+        return pd.Series(pred_mean, index=post_controls.index)

--- a/python/tests/test_market_selection.py
+++ b/python/tests/test_market_selection.py
@@ -1,0 +1,25 @@
+import unittest
+
+try:
+    import pandas as pd
+    from geolift.market_selection import prepare_wide_panel, select_test_market
+except Exception:  # pragma: no cover - package missing
+    pd = None
+
+
+@unittest.skipIf(pd is None, "pandas not available")
+class TestMarketSelection(unittest.TestCase):
+    def test_select_market(self):
+        data = {
+            "time": [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            "market": ["A", "A", "A", "B", "B", "B", "C", "C", "C"],
+            "outcome": [1, 2, 3, 1, 1, 1, 1, 1, 1],
+        }
+        df = pd.DataFrame(data)
+        panel = prepare_wide_panel(df, "market", "outcome", "time")
+        market = select_test_market(panel, pre_period_end=2)
+        self.assertEqual(market, "A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_synthetic_control.py
+++ b/python/tests/test_synthetic_control.py
@@ -1,0 +1,28 @@
+import unittest
+
+try:
+    import pandas as pd
+    import numpy as np
+    import pymc as pm
+    from geolift.synthetic_control import SyntheticControlModel
+except Exception:  # pragma: no cover - dependencies missing
+    pd = None
+
+
+@unittest.skipIf(pd is None, "dependencies not available")
+class TestSyntheticControl(unittest.TestCase):
+    def test_fit_predict(self):
+        df = pd.DataFrame({
+            "time": [0, 1, 2],
+            "treated": [1.0, 2.0, 3.0],
+            "control1": [1.0, 1.0, 1.0],
+            "control2": [1.0, 1.0, 1.0],
+        })
+        scm = SyntheticControlModel(df)
+        scm.fit(draws=10, tune=10, seed=1)
+        pred = scm.predict(df.drop(columns=["treated"]))
+        self.assertEqual(len(pred), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document how to work with long-form data in the Python README
- implement helpers to automatically select a test market
- expose helpers through the Python package
- provide a matplotlib example of fitting and plotting results
- add unit tests that skip when dependencies are missing

## Testing
- `python -m py_compile python/geolift/synthetic_control.py python/geolift/market_selection.py python/geolift/__init__.py python/examples.py`
- `python -m unittest discover -s python/tests -v` *(tests skipped)*