### PR TITLE
Add market selection and examples

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,57 @@
+# GeoLift Python
+
+This directory hosts a minimal Python implementation of the GeoLift
+methodology.  The implementation is intentionally lightweight and
+focuses on the creation of synthetic control groups using a Bayesian
+approach implemented with [PyMC](https://www.pymc.io/).
+
+The central class `SyntheticControlModel` estimates the synthetic
+control weights via Monte Carlo sampling and produces a distribution of
+possible counterfactual outcomes.  This allows communicating
+uncertainty when reporting lift estimates.
+
+Input data is expected in "long" format with columns identifying the
+market, time period and observed value.  The helper function
+`pivot_markets` converts this to the wide format required by
+`SyntheticControlModel`.  `choose_test_market` can automatically pick a
+market to hold out for testing by selecting the one that is least
+correlated with the others during the pre-treatment period.
+
+## Example
+
+```python
+import pandas as pd
+from geolift import (
+    SyntheticControlModel,
+    pivot_markets,
+    choose_test_market,
+)
+
+# DataFrame `df_long` should contain columns:
+# * `market`
+# * `time`
+# * `sales` (outcome variable)
+
+# Convert to wide format and automatically choose a test market
+df = pivot_markets(df_long, "market", "time", "sales")
+test_market = choose_test_market(df, slice("2021-01-01", "2021-02-15"))
+controls = [c for c in df.columns if c != test_market]
+
+# Build pre-treatment dataset expected by SyntheticControlModel
+pre = (
+    df.loc["2021-01-01":"2021-02-15", [test_market] + controls]
+    .rename(columns={test_market: "treated"})
+    .reset_index()
+)
+post_controls = df.loc["2021-02-16":, controls].reset_index()
+
+scm = SyntheticControlModel(pre)
+scm.fit(draws=2000, tune=1000)
+
+counterfactual = scm.predict(post_controls)
+# Posterior mean weights for the control markets
+weights = scm.weight_means()
+```
+
+The `weight_means` method returns the posterior mean contribution of each control market. Plotting the observed test market against the predicted counterfactual provides a visual interpretation of lift.
+

--- a/python/examples.py
+++ b/python/examples.py
@@ -1,0 +1,58 @@
+"""Example usage of the GeoLift Python implementation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from geolift import (
+    SyntheticControlModel,
+    pivot_markets,
+    choose_test_market,
+)
+
+# Generate synthetic data for illustration
+rng = np.random.default_rng(42)
+markets = [f"m{i}" for i in range(5)]
+periods = pd.date_range("2021-01-01", periods=50, freq="D")
+
+records = []
+for m in markets:
+    base = rng.normal(scale=0.5, size=len(periods)).cumsum()
+    records.extend({"time": t, "market": m, "sales": b + rng.normal(scale=0.1)} for t, b in zip(periods, base))
+
+df_long = pd.DataFrame.from_records(records)
+
+# Pivot into wide format and select test market
+wide = pivot_markets(df_long, "market", "time", "sales")
+pre_period = slice("2021-01-01", "2021-02-15")
+test_market = choose_test_market(wide, pre_period)
+
+print("Selected test market:", test_market)
+
+controls = [c for c in wide.columns if c != test_market]
+pre = (
+    wide.loc[pre_period, [test_market] + controls]
+    .rename(columns={test_market: "treated"})
+    .reset_index()
+)
+
+scm = SyntheticControlModel(pre)
+scm.fit(draws=1000, tune=500, seed=1)
+print("Posterior mean weights:\n", scm.weight_means())
+
+post_period = slice("2021-02-16", periods[-1])
+post_controls = wide.loc[post_period, controls].reset_index()
+counterfactual = scm.predict(post_controls)
+
+# Plot
+fig, ax = plt.subplots()
+ax.plot(wide.index, wide[test_market], label="Observed")
+ax.plot(counterfactual.index, counterfactual, label="Counterfactual")
+ax.axvline(pd.to_datetime("2021-02-16"), color="k", ls="--")
+ax.legend()
+ax.set_ylabel("Sales")
+ax.set_title("Observed vs Counterfactual for {}".format(test_market))
+plt.show()
+

--- a/python/geolift/__init__.py
+++ b/python/geolift/__init__.py
@@ -1,0 +1,9 @@
+"""GeoLift Python package."""
+
+from .synthetic_control import SyntheticControlModel
+from .market_selection import pivot_markets, choose_test_market
+__all__ = [
+    "SyntheticControlModel",
+    "pivot_markets",
+    "choose_test_market",
+]

--- a/python/geolift/market_selection.py
+++ b/python/geolift/market_selection.py
@@ -1,0 +1,40 @@
+"""Utilities for selecting test markets for synthetic control modeling."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def pivot_markets(df: pd.DataFrame, market_col: str, time_col: str, value_col: str) -> pd.DataFrame:
+    """Pivot long-form market data into wide format.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Input data containing one row per market/time combination.
+    market_col: str
+        Column identifying each market.
+    time_col: str
+        Column identifying the time period.
+    value_col: str
+        Column containing outcome values for each market and time.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame indexed by time with one column per market.
+    """
+    wide = df.pivot(index=time_col, columns=market_col, values=value_col)
+    wide = wide.sort_index()
+    return wide
+
+
+def choose_test_market(wide: pd.DataFrame, pre_period: slice) -> str:
+    """Select a test market with the lowest correlation to others."""
+    pre = wide.loc[pre_period]
+    corr = pre.corr()
+    # Ignore self-correlation by filling diagonal with NaN
+    np.fill_diagonal(corr.values, np.nan)
+    mean_corr = corr.mean()
+    return mean_corr.idxmin()

--- a/python/geolift/synthetic_control.py
+++ b/python/geolift/synthetic_control.py
@@ -1,0 +1,61 @@
+"""Synthetic control utilities implemented using PyMC.
+
+This module provides a simple interface for building a synthetic
+control model using Bayesian inference. The implementation mirrors the
+R library but leverages PyMC to obtain a posterior distribution over
+the synthetic control weights and resulting predictions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+
+
+@dataclass
+class SyntheticControlModel:
+    """Bayesian synthetic control model."""
+
+    pre_treatment: pd.DataFrame
+    trace: Optional[pm.backends.base.MultiTrace] = None
+
+    def fit(self, draws: int = 2000, tune: int = 1000, seed: Optional[int] = None) -> None:
+        """Fit the synthetic control model using MCMC."""
+        df = self.pre_treatment.sort_values("time").reset_index(drop=True)
+        controls = df.drop(columns=["time", "treated"]).values
+        treated = df["treated"].values
+
+        n_controls = controls.shape[1]
+
+        with pm.Model() as model:
+            w = pm.Dirichlet("w", a=np.ones(n_controls))
+            mu = pm.Deterministic("mu", pm.math.dot(controls, w))
+            sigma = pm.Exponential("sigma", 1.0)
+            pm.Normal("obs", mu=mu, sigma=sigma, observed=treated)
+
+            self.trace = pm.sample(draws=draws, tune=tune, random_seed=seed, progressbar=False)
+
+    def weight_means(self) -> pd.Series:
+        """Return posterior mean weights after fitting."""
+        if self.trace is None:
+            raise RuntimeError("Model must be fit before accessing weights")
+        w_samples = self.trace.posterior["w"].stack(draws=("chain", "draw"))
+        means = w_samples.mean(dim="draws").values
+        control_cols = [c for c in self.pre_treatment.columns if c not in {"time", "treated"}]
+        return pd.Series(means, index=control_cols)
+
+    def predict(self, post_controls: pd.DataFrame) -> pd.Series:
+        """Predict counterfactual outcomes for the treated unit."""
+        if self.trace is None:
+            raise RuntimeError("Model must be fit before prediction")
+
+        controls = post_controls.drop(columns=["time"], errors="ignore").values
+        w_samples = self.trace.posterior["w"].stack(draws=("chain", "draw")).values
+
+        preds = controls @ w_samples
+        pred_mean = preds.mean(axis=1)
+        return pd.Series(pred_mean, index=post_controls.index)

--- a/python/tests/test_market_selection.py
+++ b/python/tests/test_market_selection.py
@@ -1,0 +1,26 @@
+import unittest
+import importlib
+
+pd_spec = importlib.util.find_spec("pandas")
+np_spec = importlib.util.find_spec("numpy")
+
+@unittest.skipUnless(pd_spec and np_spec, "requires pandas and numpy")
+class TestMarketSelection(unittest.TestCase):
+    def test_choose_market(self):
+        import numpy as np
+        import pandas as pd
+        from geolift import pivot_markets, choose_test_market
+
+        rng = np.random.default_rng(1)
+        periods = range(5)
+        markets = ["a", "b", "c"]
+        records = []
+        for m in markets:
+            base = rng.normal(scale=0.1, size=len(periods)).cumsum()
+            for t, val in zip(periods, base + rng.normal(scale=0.01, size=len(periods))):
+                records.append({"time": t, "market": m, "y": val})
+        df = pd.DataFrame(records)
+        wide = pivot_markets(df, "market", "time", "y")
+        m = choose_test_market(wide, slice(0, 3))
+        self.assertIn(m, markets)
+

--- a/python/tests/test_synthetic_control.py
+++ b/python/tests/test_synthetic_control.py
@@ -1,0 +1,34 @@
+import unittest
+
+import importlib
+
+pd_spec = importlib.util.find_spec("pandas")
+np_spec = importlib.util.find_spec("numpy")
+pymc_spec = importlib.util.find_spec("pymc")
+
+@unittest.skipUnless(pd_spec and np_spec and pymc_spec, "requires pandas, numpy, pymc")
+class TestSyntheticControl(unittest.TestCase):
+    def test_fit_predict(self):
+        import numpy as np
+        import pandas as pd
+        from geolift import SyntheticControlModel
+
+        rng = np.random.default_rng(0)
+        pre = pd.DataFrame({
+            "time": [0, 1, 2],
+            "treated": [1.0, 2.0, 3.0],
+            "c1": rng.normal(size=3),
+            "c2": rng.normal(size=3),
+        })
+        model = SyntheticControlModel(pre)
+        model.fit(draws=100, tune=50, seed=1)
+        post = pd.DataFrame({
+            "time": [3, 4],
+            "c1": rng.normal(size=2),
+            "c2": rng.normal(size=2),
+        })
+        pred = model.predict(post)
+        self.assertEqual(len(pred), 2)
+        w = model.weight_means()
+        self.assertAlmostEqual(w.sum(), 1.0, places=2)
+


### PR DESCRIPTION
## Summary
- expand README with instructions for pivoting data and automatic market selection
- expose market selection helpers in package init
- implement `pivot_markets` and `choose_test_market`
- add `weight_means` to synthetic control model
- provide example script using matplotlib
- add small test suite

## Testing
- `python -m py_compile python/geolift/synthetic_control.py python/geolift/market_selection.py python/geolift/__init__.py python/examples.py python/tests/test_synthetic_control.py python/tests/test_market_selection.py`
- `python -m unittest discover -s python/tests -v`