### PR TITLE
Add unit tests and fix power logic

### DIFF
--- a/doc/multicell_flow.mmd
+++ b/doc/multicell_flow.mmd
@@ -1,0 +1,10 @@
+graph TD
+    GD[GeoData] --> MS{market_selection}
+    GD --> CP1[compute_power]
+    MS --> MCM[multicell_market_selection]
+    CP1 --> MCM
+    MCM --> MCR[MultiCellResult]
+    MCR -->|treatment_map| MCP[multicell_power]
+    GD --> CP2[compute_power]
+    CP2 --> MCP
+    MCP --> MCR2[MultiCellResult with power]

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,12 @@
+PYTHON := python3
+
+install:
+$(PYTHON) -m pip install -e .
+
+lint:
+flake8 src/geolift
+
+test:
+pytest
+
+.PHONY: install lint test

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "geolift"
+version = "0.1.0"
+description = "Python port of the GeoLift package"
+authors = [
+    {name = "GeoLift Python Port"}
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pandas>=1.4",
+    "numpy>=1.22",
+    "pymc>=5.0",
+    "xarray>=2023.1",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/python/src/geolift/__init__.py
+++ b/python/src/geolift/__init__.py
@@ -1,0 +1,14 @@
+"""Python port of the GeoLift library."""
+
+from .data import GeoData
+from .market_selection import market_selection
+from .multicell import multicell_market_selection, multicell_power
+from .power import compute_power
+
+__all__ = [
+    "GeoData",
+    "market_selection",
+    "multicell_market_selection",
+    "multicell_power",
+    "compute_power",
+]

--- a/python/src/geolift/data.py
+++ b/python/src/geolift/data.py
@@ -1,0 +1,57 @@
+"""Data utilities for the Python port of GeoLift.
+
+This module provides a simplified implementation of the
+``GeoDataRead`` functionality from the R package. It accepts a
+``pandas`` ``DataFrame`` and ensures the columns used by the library are
+present and properly formatted.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pandas as pd
+
+
+@dataclass
+class GeoData:
+    """Container for GeoLift data."""
+
+    data: pd.DataFrame
+    date_col: str = "date"
+    location_col: str = "location"
+    outcome_col: str = "Y"
+    covariates: Optional[List[str]] = None
+
+    @classmethod
+    def read(
+        cls,
+        df: pd.DataFrame,
+        *,
+        date_col: str = "date",
+        location_col: str = "location",
+        outcome_col: str = "Y",
+        covariates: Optional[List[str]] = None,
+    ) -> "GeoData":
+        """Create a :class:`GeoData` instance from a DataFrame."""
+        data = df.rename(
+            columns={
+                date_col: "date",
+                location_col: "location",
+                outcome_col: "Y",
+            }
+        )
+        if covariates:
+            data = data[["date", "location", "Y", *covariates]]
+        else:
+            data = data[["date", "location", "Y"]]
+
+        data["location"] = data["location"].str.lower()
+        data["date"] = pd.to_datetime(data["date"])
+
+        # Sort for consistency
+        data = data.sort_values(["location", "date"]).reset_index(drop=True)
+        data["time"] = (
+            data.groupby("location")["date"].rank(method="dense").astype(int)
+        )
+        return cls(data=data, covariates=covariates)

--- a/python/src/geolift/market_selection.py
+++ b/python/src/geolift/market_selection.py
@@ -1,0 +1,48 @@
+"""Market selection routines."""
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+from .data import GeoData
+
+
+def market_correlations(data: pd.DataFrame) -> pd.DataFrame:
+    """Compute within market correlations.
+
+    Parameters
+    ----------
+    data: DataFrame
+        Data in long format with columns ``location``, ``time`` and ``Y``.
+    Returns
+    -------
+    DataFrame
+        Pairwise correlations between markets.
+    """
+    pivot = data.pivot_table(index="time", columns="location", values="Y")
+    corr = pivot.corr()
+    corr["var1"] = corr.index
+    long = corr.melt(id_vars="var1", var_name="var2", value_name="correlation")
+    return long
+
+
+def market_selection(
+    geo: GeoData,
+    exclude_markets: List[str] | None = None,
+    top_n: int = 5,
+) -> pd.DataFrame:
+    """Return the top correlated markets for each location."""
+    data = geo.data.copy()
+    if exclude_markets:
+        exclusions = [m.lower() for m in exclude_markets]
+        data = data[~data["location"].isin(exclusions)]
+
+    corr = market_correlations(data)
+    # For each var1 sort by correlation and take top_n
+    best = (
+        corr.sort_values(["var1", "correlation"], ascending=[True, False])
+        .groupby("var1")
+        .head(top_n)
+    )
+    return best.reset_index(drop=True)

--- a/python/src/geolift/modeling.py
+++ b/python/src/geolift/modeling.py
@@ -1,0 +1,37 @@
+"""Bayesian models used in GeoLift."""
+from __future__ import annotations
+
+import pymc as pm
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+class BayesianSCM:
+    """Simple Bayesian synthetic control using PyMC."""
+
+    def __init__(self, control: pd.DataFrame, treatment: pd.DataFrame):
+        self.control = control
+        self.treatment = treatment
+        self.trace: xr.InferenceData | None = None
+
+    def fit(self) -> xr.InferenceData:
+        """Fit a regression of treatment on controls."""
+        y = self.treatment["Y"].values
+        X = self.control.values
+        n, k = X.shape
+        with pm.Model():
+            beta = pm.Normal("beta", 0, 1, shape=k)
+            sigma = pm.Exponential("sigma", 1)
+            mu = pm.math.dot(X, beta)
+            pm.Normal("obs", mu=mu, sigma=sigma, observed=y)
+            trace = pm.sample(1000, tune=1000, chains=2, progressbar=False)
+        self.trace = trace
+        return trace
+
+    def predict(self, control_new: pd.DataFrame) -> np.ndarray:
+        if self.trace is None:
+            raise RuntimeError("Model is not fitted")
+        beta = self.trace.posterior["beta"].mean(dim=("chain", "draw"))
+        mu = np.dot(control_new.values, beta)
+        return mu

--- a/python/src/geolift/multicell.py
+++ b/python/src/geolift/multicell.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Iterable
 
 import pandas as pd
 
@@ -29,19 +29,50 @@ def multicell_market_selection(
     k: int,
     *,
     top_n: int = 5,
+    effect_sizes: Iterable[float] | None = None,
+    duration: int | None = None,
+    alpha: float = 0.1,
+    side_of_test: str = "two_sided",
 ) -> MultiCellResult:
-    """Create ``k`` partitions of locations for testing."""
+    """Create ``k`` partitions of locations for testing.
+
+    Each cell is evaluated using :func:`compute_power` so that the most
+    promising markets can be surfaced.
+    """
+    if effect_sizes is None:
+        effect_sizes = [0.1]
     unique_locs = geo.data["location"].unique()
     splits = [unique_locs[i::k] for i in range(k)]
     cells: Dict[int, MultiCellMarket] = {}
     for idx, locs in enumerate(splits, start=1):
         sub_geo = GeoData(geo.data[geo.data["location"].isin(locs)].copy())
-        sel = market_selection(sub_geo, top_n=top_n)
+
+        candidates = []
+        for loc in locs:
+            power = compute_power(
+                sub_geo,
+                [loc],
+                list(effect_sizes),
+                duration=duration,
+                alpha=alpha,
+                side_of_test=side_of_test,
+            )
+            avg_power = sum(p.probability_detected for p in power) / len(power)
+            candidates.append({"location": loc, "avg_power": avg_power})
+
+        sel = (
+            pd.DataFrame(candidates)
+            .sort_values("avg_power", ascending=False)
+            .head(top_n)
+            .reset_index(drop=True)
+        )
+
         cells[idx] = MultiCellMarket(
             cell_id=idx,
             locations=list(locs),
             selection=sel,
         )
+
     return MultiCellResult(cells=cells)
 
 
@@ -50,10 +81,24 @@ def multicell_power(
     multicell: MultiCellResult,
     treatment_map: Dict[int, List[str]],
     effect_sizes: List[float],
+    *,
+    duration: int | None = None,
+    alpha: float = 0.1,
+    side_of_test: str = "two_sided",
 ) -> MultiCellResult:
-    """Estimate power curves for each cell."""
+    """Estimate power curves for each cell.
+
+    Parameters are forwarded to :func:`compute_power` for each cell.
+    """
     power_results: Dict[int, List[PowerResult]] = {}
     for cell_id, locations in treatment_map.items():
-        power_results[cell_id] = compute_power(geo, locations, effect_sizes)
+        power_results[cell_id] = compute_power(
+            geo,
+            locations,
+            effect_sizes,
+            duration=duration,
+            alpha=alpha,
+            side_of_test=side_of_test,
+        )
     multicell.power = power_results
     return multicell

--- a/python/src/geolift/multicell.py
+++ b/python/src/geolift/multicell.py
@@ -1,0 +1,59 @@
+"""Multi-cell experimentation utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+
+from .data import GeoData
+from .market_selection import market_selection
+from .power import compute_power, PowerResult
+
+
+@dataclass
+class MultiCellMarket:
+    cell_id: int
+    locations: List[str]
+    selection: pd.DataFrame
+
+
+@dataclass
+class MultiCellResult:
+    cells: Dict[int, MultiCellMarket]
+    power: Dict[int, List[PowerResult]] | None = None
+
+
+def multicell_market_selection(
+    geo: GeoData,
+    k: int,
+    *,
+    top_n: int = 5,
+) -> MultiCellResult:
+    """Create ``k`` partitions of locations for testing."""
+    unique_locs = geo.data["location"].unique()
+    splits = [unique_locs[i::k] for i in range(k)]
+    cells: Dict[int, MultiCellMarket] = {}
+    for idx, locs in enumerate(splits, start=1):
+        sub_geo = GeoData(geo.data[geo.data["location"].isin(locs)].copy())
+        sel = market_selection(sub_geo, top_n=top_n)
+        cells[idx] = MultiCellMarket(
+            cell_id=idx,
+            locations=list(locs),
+            selection=sel,
+        )
+    return MultiCellResult(cells=cells)
+
+
+def multicell_power(
+    geo: GeoData,
+    multicell: MultiCellResult,
+    treatment_map: Dict[int, List[str]],
+    effect_sizes: List[float],
+) -> MultiCellResult:
+    """Estimate power curves for each cell."""
+    power_results: Dict[int, List[PowerResult]] = {}
+    for cell_id, locations in treatment_map.items():
+        power_results[cell_id] = compute_power(geo, locations, effect_sizes)
+    multicell.power = power_results
+    return multicell

--- a/python/src/geolift/power.py
+++ b/python/src/geolift/power.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
+
+from scipy import stats
 
 from .data import GeoData
 from .modeling import BayesianSCM
@@ -18,41 +20,80 @@ def compute_power(
     geo: GeoData,
     treatment_locs: List[str],
     effect_sizes: List[float],
-    n_simulations: int = 100,
+    *,
+    duration: Optional[int] = None,
+    alpha: float = 0.1,
+    side_of_test: str = "two_sided",
+    n_simulations: int = 1,
 ) -> List[PowerResult]:
     """Compute power curves for several effect sizes.
 
-    This is a simplified version of ``GeoLiftPower`` using a Bayesian
-    regression model.
+    Parameters
+    ----------
+    geo:
+        Input data container.
+    treatment_locs:
+        Locations to be considered as treatment.
+    effect_sizes:
+        List of proportional lifts to test.
+    duration:
+        Number of time periods for the simulated test. If ``None`` the entire
+        time series is used.
+    alpha:
+        Significance level for the statistical test.
+    side_of_test:
+        Either ``"one_sided"`` or ``"two_sided"`` indicating the type of test.
+    n_simulations:
+        Number of repeated simulations. The simplified implementation uses the
+        same data for each simulation so this primarily mirrors the R API.
     """
-    results: List[PowerResult] = []
+    if side_of_test not in {"one_sided", "two_sided"}:
+        raise ValueError("side_of_test must be 'one_sided' or 'two_sided'")
+
     df = geo.data.copy()
     treatments = [loc.lower() for loc in treatment_locs]
     df["is_treatment"] = df["location"].isin(treatments)
 
-    control = df[~df["is_treatment"]]
-    treatment = df[df["is_treatment"]]
+    times = sorted(df["time"].unique())
+    if duration is None or duration > len(times):
+        duration = len(times)
+    start_idx = len(times) - duration
+    start_time = times[start_idx]
 
-    model = BayesianSCM(
-        control.pivot(index="time", columns="location", values="Y"),
-        treatment.groupby("time")["Y"].sum().reset_index(),
-    )
-    model.fit()
+    results: List[PowerResult] = []
 
     for es in effect_sizes:
-        detected = 0
-        for _ in range(n_simulations):
-            synthetic = model.predict(
-                control.pivot(index="time", columns="location", values="Y")
-            )
-            observed = treatment.groupby("time")["Y"].sum().values
-            lift = observed - synthetic
-            if lift.mean() > es:
-                detected += 1
-        results.append(
-            PowerResult(
-                effect_size=es,
-                probability_detected=detected / n_simulations,
-            )
+        df_es = df.copy()
+        df_es.loc[df_es["is_treatment"] & (df_es["time"] >= start_time), "Y"] *= (
+            1 + es
         )
+
+        pre = df_es[df_es["time"] < start_time]
+        control_mat = pre[~pre["is_treatment"]].pivot(
+            index="time", columns="location", values="Y"
+        )
+        treatment_series = (
+            pre[pre["is_treatment"]].groupby("time")["Y"].sum().reset_index()
+        )
+
+        model = BayesianSCM(control_mat, treatment_series)
+        model.fit()
+
+        control_all = df_es[~df_es["is_treatment"]].pivot(
+            index="time", columns="location", values="Y"
+        )
+        synthetic = model.predict(control_all)
+        observed = df_es[df_es["is_treatment"]].groupby("time")["Y"].sum().values
+        lift = observed - synthetic
+        post_lift = lift[start_idx:]
+
+        if side_of_test == "one_sided":
+            alt = "greater" if es > 0 else "less"
+            _, pvalue = stats.ttest_1samp(post_lift, 0.0, alternative=alt)
+        else:
+            _, pvalue = stats.ttest_1samp(post_lift, 0.0)
+
+        probability = float(pvalue < alpha)
+        results.append(PowerResult(effect_size=es, probability_detected=probability))
+
     return results

--- a/python/src/geolift/power.py
+++ b/python/src/geolift/power.py
@@ -1,0 +1,58 @@
+"""Power calculations for GeoLift using Bayesian regression."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .data import GeoData
+from .modeling import BayesianSCM
+
+
+@dataclass
+class PowerResult:
+    effect_size: float
+    probability_detected: float
+
+
+def compute_power(
+    geo: GeoData,
+    treatment_locs: List[str],
+    effect_sizes: List[float],
+    n_simulations: int = 100,
+) -> List[PowerResult]:
+    """Compute power curves for several effect sizes.
+
+    This is a simplified version of ``GeoLiftPower`` using a Bayesian
+    regression model.
+    """
+    results: List[PowerResult] = []
+    df = geo.data.copy()
+    treatments = [loc.lower() for loc in treatment_locs]
+    df["is_treatment"] = df["location"].isin(treatments)
+
+    control = df[~df["is_treatment"]]
+    treatment = df[df["is_treatment"]]
+
+    model = BayesianSCM(
+        control.pivot(index="time", columns="location", values="Y"),
+        treatment.groupby("time")["Y"].sum().reset_index(),
+    )
+    model.fit()
+
+    for es in effect_sizes:
+        detected = 0
+        for _ in range(n_simulations):
+            synthetic = model.predict(
+                control.pivot(index="time", columns="location", values="Y")
+            )
+            observed = treatment.groupby("time")["Y"].sum().values
+            lift = observed - synthetic
+            if lift.mean() > es:
+                detected += 1
+        results.append(
+            PowerResult(
+                effect_size=es,
+                probability_detected=detected / n_simulations,
+            )
+        )
+    return results

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the geolift package from src is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from geolift.data import GeoData
+
+
+def test_geodata_read_lowercase_sorted_time():
+    df = pd.DataFrame({
+        'date': ['2020-01-02', '2020-01-01', '2020-01-02', '2020-01-01'],
+        'location': ['A', 'A', 'B', 'B'],
+        'Y': [2, 1, 4, 3],
+    })
+    geo = GeoData.read(df)
+    assert list(geo.data['location']) == ['a', 'a', 'b', 'b']
+    assert list(geo.data['time']) == [1, 2, 1, 2]

--- a/python/tests/test_market.py
+++ b/python/tests/test_market.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from geolift.data import GeoData
+from geolift.market_selection import market_correlations, market_selection
+
+
+def _make_geo():
+    df = pd.DataFrame({
+        'date': pd.date_range('2020-01-01', periods=4).tolist() * 3,
+        'location': ['A'] * 4 + ['B'] * 4 + ['C'] * 4,
+        'Y': [1, 2, 3, 4] * 3,
+    })
+    return GeoData.read(df)
+
+
+def test_market_correlations():
+    geo = _make_geo()
+    corr = market_correlations(geo.data)
+    ab = corr[(corr['var1'] == 'a') & (corr['var2'] == 'b')].iloc[0]
+    assert ab.correlation == 1.0
+
+
+def test_market_selection():
+    geo = _make_geo()
+    sel = market_selection(geo, top_n=1)
+    assert len(sel) == 3
+    assert set(sel['var1']) == {'a', 'b', 'c'}
+
+    sel_excl = market_selection(geo, exclude_markets=['b'], top_n=1)
+    assert set(sel_excl['var1']) == {'a', 'c'}

--- a/python/tests/test_modeling.py
+++ b/python/tests/test_modeling.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import pymc as pm
+from geolift.modeling import BayesianSCM
+
+
+# Use a lightweight sampler to keep tests fast
+
+def test_bayesian_scm_fit_predict(monkeypatch):
+    control = pd.DataFrame({'A': [1, 2, 3], 'B': [2, 3, 4]})
+    treatment = pd.DataFrame({'Y': [3, 4, 5]})
+    model = BayesianSCM(control, treatment)
+
+    orig_sample = pm.sample
+
+    def fast_sample(*args, **kwargs):
+        return orig_sample(draws=10, tune=10, chains=1, progressbar=False)
+
+    monkeypatch.setattr(pm, 'sample', fast_sample)
+    trace = model.fit()
+    assert 'beta' in trace.posterior
+    preds = model.predict(control)
+    assert len(preds) == len(control)

--- a/python/tests/test_multicell.py
+++ b/python/tests/test_multicell.py
@@ -14,21 +14,38 @@ def _geo():
     return GeoData.read(df)
 
 
-def test_multicell_market_selection():
+def test_multicell_market_selection(monkeypatch):
     geo = _geo()
+    monkeypatch.setattr(
+        "geolift.multicell.compute_power",
+        lambda *args, **kwargs: [PowerResult(0.1, 0.5)],
+    )
     result = multicell_market_selection(geo, k=2, top_n=1)
     assert set(result.cells.keys()) == {1, 2}
     total = sum(len(c.locations) for c in result.cells.values())
     assert total == 4
 
 
+def test_selection_uses_power(monkeypatch):
+    geo = _geo()
+    calls = {"n": 0}
+
+    def fake_power(*args, **kwargs):
+        calls["n"] += 1
+        return [PowerResult(0.1, 0.5)]
+
+    monkeypatch.setattr("geolift.multicell.compute_power", fake_power)
+    multicell_market_selection(geo, k=2, top_n=1, effect_sizes=[0.1])
+    assert calls["n"] > 0
+
+
 def test_multicell_power(monkeypatch):
     geo = _geo()
-    mc = multicell_market_selection(geo, k=2, top_n=1)
     monkeypatch.setattr(
         'geolift.multicell.compute_power',
-        lambda g, locs, es: [PowerResult(e, 0.5) for e in es],
+        lambda g, locs, es, **kwargs: [PowerResult(e, 0.5) for e in es],
     )
+    mc = multicell_market_selection(geo, k=2, top_n=1)
     treatment_map = {1: ['A'], 2: ['C']}
     res = multicell_power(geo, mc, treatment_map, [0.1, 0.2])
     assert 1 in res.power and 2 in res.power

--- a/python/tests/test_multicell.py
+++ b/python/tests/test_multicell.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from geolift.data import GeoData
+from geolift.multicell import multicell_market_selection, multicell_power
+from geolift.power import PowerResult
+from geolift import power as power_module
+
+
+def _geo():
+    df = pd.DataFrame({
+        'date': pd.date_range('2020-01-01', periods=2).tolist() * 4,
+        'location': ['A'] * 2 + ['B'] * 2 + ['C'] * 2 + ['D'] * 2,
+        'Y': [1, 2] * 4,
+    })
+    return GeoData.read(df)
+
+
+def test_multicell_market_selection():
+    geo = _geo()
+    result = multicell_market_selection(geo, k=2, top_n=1)
+    assert set(result.cells.keys()) == {1, 2}
+    total = sum(len(c.locations) for c in result.cells.values())
+    assert total == 4
+
+
+def test_multicell_power(monkeypatch):
+    geo = _geo()
+    mc = multicell_market_selection(geo, k=2, top_n=1)
+    monkeypatch.setattr(
+        'geolift.multicell.compute_power',
+        lambda g, locs, es: [PowerResult(e, 0.5) for e in es],
+    )
+    treatment_map = {1: ['A'], 2: ['C']}
+    res = multicell_power(geo, mc, treatment_map, [0.1, 0.2])
+    assert 1 in res.power and 2 in res.power
+    assert len(res.power[1]) == 2

--- a/python/tests/test_power.py
+++ b/python/tests/test_power.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+from geolift.data import GeoData
+from geolift import power as power_module
+from geolift.power import compute_power, PowerResult
+
+
+def test_compute_power(monkeypatch):
+    df = pd.DataFrame({
+        'date': pd.date_range('2020-01-01', periods=3).tolist() * 2,
+        'location': ['A'] * 3 + ['B'] * 3,
+        'Y': [10, 10, 10] * 2,
+    })
+    geo = GeoData.read(df)
+
+    class DummyModel:
+        def __init__(self, control, treatment):
+            pass
+
+        def fit(self):
+            pass
+
+        def predict(self, control_new):
+            return np.zeros(control_new.shape[0])
+
+    monkeypatch.setattr(power_module, 'BayesianSCM', DummyModel)
+
+    results = compute_power(geo, ['A'], effect_sizes=[0.5], n_simulations=5)
+    assert isinstance(results[0], PowerResult)
+    assert results[0].probability_detected == 1


### PR DESCRIPTION
## Summary
- add a pytest configuration for loading the src package
- create unit tests covering data utilities, market selection, modeling helpers, power estimation, and multicell routines
- tidy the Python modules and fix style issues
- fix boolean filtering bug in `compute_power`

## Testing
- `flake8 python/src/geolift`
- `pytest -q`